### PR TITLE
Add RRMS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ SampleData
 *.log
 
 # Testing scripts
-tests/SCRIPTS.txt
+scripts/

--- a/README.md
+++ b/README.md
@@ -7,14 +7,10 @@
 LongReadSum supports FASTA, FASTQ, BAM, FAST5, and sequencing_summary.txt file formats for quick generation of QC data in HTML and text format.
 
 ## Software requirements
-Please refer to `environment.yml` for detail. For your quick reference, LongReadSum needs
-```
-  - python=3.9
-  - hdf5
-  - htslib
-  - swig
-  - matplotlib
-```
+Please refer to the conda
+[environment.yml](https://github.com/WGLab/LongReadSum/blob/main/environment.yml)
+file for all required packages.
+
 # Installation using Anaconda (Linux 64-bit)
 First, install [Anaconda](https://www.anaconda.com/).
 LongReadSum can be installed using the following command:
@@ -71,34 +67,20 @@ export HDF5_PLUGIN_PATH=/full/path/to/ont-vbz-hdf-plugin-1.0.1-Linux/usr/local/h
 
 
 ## Running
-Activate the conda environment:
-
-`conda activate lrst_py39`
-
-To test that you are using the correct Python interpreter, run:
-
-`which python`
-
-This should point to the environment's Python interpreter path:
-
-`~/miniconda3/envs/lrst_py39/bin/python`
-
-If the path is incorrect, export its location to `PATH`:
-
-`export PATH=~/miniconda3/envs/lrst_py39/bin:$PATH`
-
-Then you can run LongReadSum using the following command:
-
-`python /path/to/LongReadSum [arguments]`
+Activate the conda environment and then run with arguments:
+```
+conda activate longreadsum
+python longreadsum [arguments]
+```
 
 # General Usage
 
 Specifying input files:
 
 ```
-usage: LongReadSum [-h] {fa,fq,f5,seqtxt,bam} ...
+usage: longreadsum [-h] {fa,fq,f5,f5s,seqtxt,bam,rrms} ...
 
-QC tools for long-read sequencing data
+Fast and comprehensive QC for long read sequencing data.
 
 positional arguments:
   {fa,fq,f5,seqtxt,bam}
@@ -108,16 +90,23 @@ positional arguments:
     f5s                 FAST5 file input with signal statistics output    
     seqtxt              sequencing_summary.txt input
     bam                 BAM file input
+    rrms                RRMS BAM file input
 
 optional arguments:
   -h, --help            show this help message and exit
 
 Example with single inputs:
-	python LongReadSum bam -i path/to/input.bam -o /output_directory/
+	longreadsum bam -i input.bam -o output_directory -t 12
 
 Example with multiple inputs:
-	python LongReadSum bam -I "path/to/input1.bam, path/to/input2.bam" -o /output_directory/
-	python LongReadSum bam -P "path/to/*.bam" -o /output_directory/
+	longreadsum bam -I input1.bam, input2.bam -o output_directory
+	longreadsum bam -P *.bam -o output_directory
+
+RRMS example:
+  longreadsum rrms --csv rrms_results.csv --input input.bam --output output_directory --threads 12
+
+FAST5 signal mode example:
+  longreadsum f5s --input input.fast5 --output output_directory
 ```
 
 # Revision history

--- a/__main__.py
+++ b/__main__.py
@@ -1,21 +1,6 @@
-"""
-__main__.py:
-Call the command-line interface.
-"""
-
-import os
+# __main__.py: Call the command-line interface.
 
 from src import cli
-
-
-from os.path import dirname, abspath
-
-# Get the parent directory
-parent_dir = dirname(dirname(abspath(__file__)))
-
-# # Set the HDF5 plugin path
-# os.environ['HDF5_PLUGIN_PATH'] = os.path.join(parent_dir, "lib")
-print("HDF5_PLUGIN_PATH is " + os.environ.get('HDF5_PLUGIN_PATH', ''))
 
 
 def main():

--- a/include/bam_module.h
+++ b/include/bam_module.h
@@ -16,8 +16,13 @@ public:
     std::map<std::string, bool> secondary_alignment;
     std::map<std::string, bool> supplementary_alignment;
 
+    int run(Input_Para& input_params, Output_BAM& final_output);
     int calculateStatistics(Input_Para& input_params, Output_BAM& final_output);
     static void batchStatistics(HTSReader& reader, int batch_size, Input_Para& input_params, Output_BAM& ref_output, std::mutex& bam_mutex, std::mutex& output_mutex, std::mutex& cout_mutex);
+
+    // RRMS
+    // Read the RRMS CSV file and store the read IDs (accepted or rejected)
+    std::unordered_set<std::string> readRRMSFile(std::string rrms_csv_file, bool accepted_reads);
 };
 
 #endif

--- a/include/hts_reader.h
+++ b/include/hts_reader.h
@@ -35,7 +35,7 @@ class HTSReader {
         int updateReadAndBaseCounts(bam1_t* record, Basic_Seq_Statistics* basic_qc, uint64_t *base_quality_distribution);
 
         // Read the next batch of records from the BAM file
-        int readNextRecords(int batch_size, Output_BAM & output_data, std::mutex & read_mutex);
+        int readNextRecords(int batch_size, Output_BAM & output_data, std::mutex & read_mutex, std::unordered_set<std::string>& read_ids);
 
         // Return if the reader has finished reading the BAM file
         bool hasNextRecord();

--- a/include/input_parameters.h
+++ b/include/input_parameters.h
@@ -8,6 +8,7 @@ Define the Python bindings from our C++ modules
 
 #include <vector>
 #include <string>
+#include <unordered_set>  // For RRMS read ID filtering
 #define MAX_INPUT_FILES 2048
 
 
@@ -28,6 +29,9 @@ public:
     std::string output_folder;  // Output folder
     std::string input_files[MAX_INPUT_FILES];  // Input files
     std::string read_ids;  // Read IDs comma-separated (FAST5 signal module)
+    std::string rrms_csv;  // CSV file with accepted/rejected read IDs (RRMS module)
+    bool rrms_filter;  // Generate RRMS stats for accepted (true) or rejected (false) reads
+    std::unordered_set<std::string> rrms_read_ids;  // List of read IDs from RRMS CSV file (accepted or rejected)
 
     // Functions
     std::string add_input_file(const std::string& _ip_file);

--- a/include/output_data.h
+++ b/include/output_data.h
@@ -14,9 +14,8 @@ Define the output structures for each module.
 #include "input_parameters.h"
 
 #define MAX_READ_LENGTH 10485760
-#define MAX_MAP_QUALITY 256
-#define MAX_BASE_QUALITY 256
-#define MAX_READ_QUALITY 256
+#define MAX_BASE_QUALITY 100
+#define MAX_READ_QUALITY 100
 #define MAX_SIGNAL_VALUE 5000
 #define PERCENTAGE_ARRAY_SIZE 101
 #define ZeroDefault 0

--- a/src/generate_html.py
+++ b/src/generate_html.py
@@ -20,12 +20,8 @@ class ST_HTML_Generator:
             self.more_input_files = False
 
     def generate_header(self):
-        if self.static:
-            self.html_writer = open(
-                self.input_para["output_folder"] + '/' + self.input_para["out_prefix"] + "statistics.html", 'w')
-        else:
-            self.html_writer = open(
-                self.input_para["output_folder"] + '/' + self.input_para["out_prefix"] + "statistics_dynamic.html", 'w')
+        html_filepath = self.input_para["output_folder"] + '/' + self.input_para["out_prefix"] + ".html"
+        self.html_writer = open(html_filepath, 'w')
         self.html_writer.write("<html>")
         self.html_writer.write("<head>")
         self.html_writer.write("<title>")
@@ -290,9 +286,9 @@ class ST_HTML_Generator:
         key_index += 1
 
         self.html_writer.write('</div>')
-
+    
+    # Generate links in the left panel
     def generate_left_signal_data(self, read_names):
-        """Generate links in the left panel."""
         self.html_writer.write('<div class="summary">');
         self.html_writer.write('<h2>Summary</h2>')
         self.html_writer.write('<ul>')
@@ -320,8 +316,8 @@ class ST_HTML_Generator:
         self.html_writer.write("</ul>")
         self.html_writer.write('</div>')
 
+    # Generate tables and plots in the right section
     def generate_right_signal_data(self, read_names, signal_plot):
-        """Generate tables and plots in the right section."""
 
         self.html_writer.write('<div class="main">')
 
@@ -366,10 +362,8 @@ class ST_HTML_Generator:
         self.html_writer.write("</html>")
         self.html_writer.close()
 
+    # Main function for generating the HTML.
     def generate_st_html(self, signal_plots=False):
-        """
-        Top-level function for generating the HTML.
-        """
         if signal_plots:
             self.generate_header()
             # Get the signal plots

--- a/src/input_parameters.cpp
+++ b/src/input_parameters.cpp
@@ -10,6 +10,7 @@ Input_Para::Input_Para(){
     downsample_percentage = 100;
     other_flags = 0;
     user_defined_fastq_base_qual_offset = -1;
+    rrms_csv = "";
 }
 
 Input_Para::~Input_Para(){

--- a/src/module_caller.cpp
+++ b/src/module_caller.cpp
@@ -10,7 +10,7 @@ int callBAMModule(Input_Para &_input_data, Output_BAM &py_output_bam)
 {
 //    BAM_Module _bam_module(_input_data);
     BAM_Module module;
-    int exit_code = module.calculateStatistics(_input_data, py_output_bam);
+    int exit_code = module.run(_input_data, py_output_bam);
     return exit_code;
 }
 


### PR DESCRIPTION
This adds support for RRMS data filtering via a provided CSV with the appropriate columns (read_id and decision).

`longreadsum rrms --csv rrms_results.csv --input input.bam --output output_directory --threads 12`

The update simply calls the BAM module once for each type of read (accepted and rejected), and filters the CSV read ids based on this flag. Thus two QC reports are created with suffix  __rejected.html_ (left) or __accepted.html_ (right):



![image](https://github.com/WGLab/LongReadSum/assets/14855676/9225ff80-ad44-41b1-b6e5-73547aee20e7)

![image](https://github.com/WGLab/LongReadSum/assets/14855676/4fab10ff-03a1-43eb-b845-cb8f537efd89)
